### PR TITLE
refs #63, #67 Renamed prepare-build and build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,13 @@ documentation from the default lifecycle with the asciidoctor-maven-plugin.
 In this section I will tell you the most recent changes.
 This section will disappear with the final release.
 
+.2020/04/23
+* Renamed phase `prepare-build` to `asciidoctor-prepare-convert`.
+* Renamed phase `build` to `asciidoctor-convert`.
+* Renamed phase `prepare-theme` to `asciidoctor-prepare-theme`.
+* Renamed phase `theme` to `asciidoctor-theme`.
+* Renamed all files and examples to conform to new names.
+
 .2020/04/20
 * Big redesign of `UploadMojo` code (now called `PublishMojo`).
 * `upload` phase renamed to `asciidoctor-publish`.
@@ -140,23 +147,16 @@ without the use of profiles. These are the phases of this lifecycle (in sequenti
 
 [%header%autowidth.spread,cols="h,,"]
 |===
-|Phase          |Description |Mojo
-//----------------------
-|theme          |In this phase the themes are downloaded from remote repositories,
+|Phase                       |Description |Mojo
+|asciidoctor-prepare-theme   |Prepare the theme download. |
+|asciidoctor-theme           |In this phase the themes are downloaded from remote repositories,
 if required, unzipped and copying common resources to a folder. | ThemeMojo
-|prepare-build  |Actions required before the build.
-Copy the theme to another location, modify it contents...|
-|build          |The `process-asciidoc` should be attached to this phase, to build the documentation|
-|prepare-upload |Actions required before the upload phase|
-|upload         |Actions required for uploading generated content|UploadMojo
-|notice         |Actions required for notifying users new documentation version|
+|asciidoctor-prepare-convert |Actions required before the asciidoctor conversion. |
+|asciidoctor-convert         |The `process-asciidoc` is attached to this phase, to build the documentation. |
+|asciidoctor-prepare-publish |Actions required before publishing documents. |
+|asciidoctor-publish         |Publishing generated content in a remote webdav server, a local filesystem... | PublishMojo
+|notice                      |Actions required for notifying users new documentation version. |
 |===
-
-You will notice that the `asciidoctor-lifecycle@build` goal is not bound by default to the `asciidoctor@process-asciidoc` goal.
-
-The main reason is that if you define a shared configuration and several executions,
-an additional document corresponding to the default backend (dockbook) will be generated.
-This is by design of the `asciidoctor-maven-plugin`.
 
 == Themes
 === What is a theme?

--- a/lifecycle.adoc
+++ b/lifecycle.adoc
@@ -3,13 +3,12 @@
 [%header%autowidth.spread,cols="h,,"]
 |===
 |Phase                       |Description |Mojo
-|asciidoctor-prepare-theme   |Prepare the theme download
+|asciidoctor-prepare-theme   |Prepare the theme download. |
 |asciidoctor-theme           |In this phase the themes are downloaded from remote repositories,
 if required, unzipped and copying common resources to a folder. | ThemeMojo
-|prepare-build               |Actions required before the build.
-Copy the theme to another location, modify it contents...|
-|build                       |The `process-asciidoc` should be attached to this phase, to build the documentation|
-|asciidoctor-prepare-publish |Actions required before the `asciidoctor-publish` phase|
-|asciidoctor-publish         |Actions required for publishing generated content|UploadMojo
-|notice                      |Actions required for notifying users new documentation version|
+|asciidoctor-prepare-convert |Actions required before the asciidoctor conversion. |
+|asciidoctor-convert         |The `process-asciidoc` is attached to this phase, to build the documentation. |
+|asciidoctor-prepare-publish |Actions required before publishing documents. |
+|asciidoctor-publish         |Publishing generated content in a remote webdav server, a local filesystem... | PublishMojo
+|notice                      |Actions required for notifying users new documentation version. |
 |===

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -9,16 +9,17 @@
                 <phases>
                     <phase>asciidoctor-prepare-theme</phase>
                     <phase>asciidoctor-theme</phase>
-                    <phase>prepare-build</phase>
-                    <phase>build</phase>
+                    <phase>asciidoctor-prepare-convert</phase>
+                    <phase>asciidoctor-convert</phase>
+                    <phase>asciidoctor-post-convert</phase>
                     <phase>asciidoctor-prepare-publish</phase>
                     <phase>asciidoctor-publish</phase>
                     <phase>notify</phase>
                 </phases>
                 <default-phases>
                     <asciidoctor-theme>com.coutemeier.maven.plugins:asciidoctor-lifecycle-maven-plugin:asciidoctor-theme</asciidoctor-theme>
-                    <prepare-build>com.coutemeier.maven.plugins:asciidoctor-lifecycle-maven-plugin:prepare-sources</prepare-build>
-                    <build>org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc</build>
+                    <asciidoctor-prepare-convert>com.coutemeier.maven.plugins:asciidoctor-lifecycle-maven-plugin:prepare-sources</asciidoctor-prepare-convert>
+                    <asciidoctor-convert>org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc</asciidoctor-convert>
                     <asciidoctor-publish>com.coutemeier.maven.plugins:asciidoctor-lifecycle-maven-plugin:asciidoctor-publish</asciidoctor-publish>
                 </default-phases>
             </configuration>

--- a/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/PhasesIT.java
+++ b/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/PhasesIT.java
@@ -13,10 +13,10 @@ extends AbstractMojoIT {
     }
 
     @Test
-    public void prepareBuildTest()
+    public void perpareConvertBuildTest()
     throws Exception {
         multimoduleForProject() //
-            .execute( "prepare-build" ) //
+            .execute( "asciidoctor-prepare-convert" ) //
             .assertErrorFreeLog();
         Assert.assertTrue(
             this.subValidator.themeFilesExists()
@@ -25,10 +25,10 @@ extends AbstractMojoIT {
     }
 
     @Test
-    public void buildTest()
+    public void convertTest()
     throws Exception {
         multimoduleForProject()
-            .execute( "build" )
+            .execute( "asciidoctor-convert" )
             .assertErrorFreeLog();
         Assert.assertTrue(
             this.subValidator.themeFilesExists()
@@ -49,5 +49,4 @@ extends AbstractMojoIT {
             && this.subValidator.generatedFilesNotExists()
         );
     }
-
 }

--- a/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/PrepareSourcesIT.java
+++ b/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/PrepareSourcesIT.java
@@ -16,7 +16,7 @@ extends AbstractMojoIT {
     public void prepareSourcesIOExceptionTest()
     throws Exception {
         forProject( "prepareSources-ioexception" ) //
-            .execute( "prepare-build" ) //
+            .execute( "asciidoctor-prepare-convert" ) //
             .assertLogText( Messages.PREPARE_SOURCES_ERROR_PREPARING );
         Assert.assertTrue( this.validator.buildDirectoryNotExists() );
     }
@@ -25,7 +25,7 @@ extends AbstractMojoIT {
     public void prepareSourcesSourceDirectoryNotExistsTest()
     throws Exception {
         forProject( "prepareSources-sourceDirectoryNotExists" ) //
-            .execute( "prepare-build" ) //
+            .execute( "asciidoctor-prepare-convert" ) //
             .assertErrorFreeLog();
         Assert.assertTrue( this.validator.indexNotExists() );
     }

--- a/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/SkipParameterIT.java
+++ b/src/test/java/com/coutemeier/maven/plugins/asciidoctor/lifecycle/SkipParameterIT.java
@@ -17,7 +17,7 @@ extends AbstractMojoIT{
     throws Exception {
         multimoduleForProject()
             .withCliOptions( SKIP )
-            .execute( "build" )
+            .execute( "asciidoctor-convert" )
             .assertErrorFreeLog();
         Assert.assertTrue( subValidator.themeNotExists() && subValidator.dependencyNotExists() );
     }

--- a/src/test/projects/abstract/skip-parameter-true/pom.xml
+++ b/src/test/projects/abstract/skip-parameter-true/pom.xml
@@ -30,7 +30,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>
@@ -42,5 +42,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/test/projects/multimodule/pom.xml
+++ b/src/test/projects/multimodule/pom.xml
@@ -24,15 +24,6 @@
                     <groupId>org.asciidoctor</groupId>
                     <artifactId>asciidoctor-maven-plugin</artifactId>
                     <version>2.0.0-RC.1</version>
-    <!--
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj</artifactId>
-                            <version>${emprego-dependency.asciidoctorj}</version>
-                        </dependency>
-                    </dependencies>
-                -->
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/test/projects/phases/build/pom.xml
+++ b/src/test/projects/phases/build/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.coutemeier.maven.plugins.test</groupId>
-    <artifactId>build</artifactId>
+    <artifactId>asciidoctor-convert</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
@@ -56,7 +56,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/phases/prepare-convert/pom.xml
+++ b/src/test/projects/phases/prepare-convert/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.coutemeier.maven.plugins.test</groupId>
-    <artifactId>prepare-build</artifactId>
+    <artifactId>prepare-convert</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
@@ -52,7 +52,7 @@
                 <executions>
                     <execution>
                         <id>dependency-copy-to-folder</id>
-                        <phase>prepare-build</phase>
+                        <phase>asciidoctor-prepare-convert</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>

--- a/src/test/projects/prepareSources-ioexception/pom.xml
+++ b/src/test/projects/prepareSources-ioexception/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.coutemeier.maven.plugins.test</groupId>
-    <artifactId>build</artifactId>
+    <artifactId>prepare-sources-ioexception</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
@@ -32,7 +32,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/prepareSources-sourceDirectoryNotExists/pom.xml
+++ b/src/test/projects/prepareSources-sourceDirectoryNotExists/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.coutemeier.maven.plugins.test</groupId>
-    <artifactId>build</artifactId>
+    <artifactId>prepare-sources-source-directory</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
@@ -32,7 +32,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/publish-to-webdav/pom.xml
+++ b/src/test/projects/publish-to-webdav/pom.xml
@@ -38,7 +38,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/publish/inputDirectory-doesnt-exists/pom.xml
+++ b/src/test/projects/publish/inputDirectory-doesnt-exists/pom.xml
@@ -32,7 +32,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/publish/publish-to-folder/pom.xml
+++ b/src/test/projects/publish/publish-to-folder/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/publish/to-folder-noproxy-noauthentication/pom.xml
+++ b/src/test/projects/publish/to-folder-noproxy-noauthentication/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>

--- a/src/test/projects/publish/wagon-doesnt-support-directcopy/pom.xml
+++ b/src/test/projects/publish/wagon-doesnt-support-directcopy/pom.xml
@@ -31,7 +31,7 @@
                 <executions>
                     <execution>
                         <id>output-html</id>
-                        <phase>build</phase>
+                        <phase>asciidoctor-convert</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>


### PR DESCRIPTION
Phases renamed to `asciidoctor-prepare-convert` and `asciidoctor-convert`.
All related strings, resources and tests projects was renamed too.